### PR TITLE
Start signal and msg on player leave

### DIFF
--- a/agbic/config/dev.exs
+++ b/agbic/config/dev.exs
@@ -33,5 +33,6 @@ config :logger, :console, format: "[$level] $message\n"
 # in production as building large stacktraces may be expensive.
 config :phoenix, :stacktrace_depth, 20
 
-config :matchmaker, :max_subscribers, 4
-config :matchmaker, :room_mod, Agbic.GameRoom
+config :matchmaker, Matchmaker.Supervisor, 
+    max_subscribers: 4,
+    room_adapter: Agbic.GameRoom

--- a/agbic/lib/agbic/game_room.ex
+++ b/agbic/lib/agbic/game_room.ex
@@ -1,12 +1,13 @@
 defmodule Agbic.GameRoom do
   @behaviour Matchmaker.Room
   use GenServer
+  require Logger
 
   # TODO: convert to agent, and let the channels monitor the room
 
 
-  def start_link(room_id) do
-    GenServer.start_link(__MODULE__, {:ok, room_id}, [])
+  def start_link(room_id, room_server) do
+    GenServer.start_link(__MODULE__, {:ok, room_id, room_server}, [])
   end
 
   def join(server, _channel_pid, socket) do
@@ -14,28 +15,44 @@ defmodule Agbic.GameRoom do
   end
 
   def leave(server, pid) do
-    # TODO:
+    # TODO: must remove player, and also bcast to others
+    GenServer.call(server, {:leave, pid})
   end
 
   def close(server) do
+    Logger.debug "GameRoom stopping..."
     GenServer.stop(server, :normal)
   end
 
   # ---
 
-  def init({:ok, room_id}) do
-    {:ok, %{:room_id => room_id, :players => %{}}}
+  def init({:ok, room_id, room_server}) do
+    ref = Process.monitor(room_server)
+    {:ok, %{:room_id => room_id, 
+      :players => Map.new(), # map player_num to socket
+      :player_pids => Map.new(), # map pid to player_num
+      :room_server => room_server, 
+      :server_ref => ref}}
   end
 
   def handle_call({:join, socket}, _from, state) do
-    Process.link(socket.channel_pid) # trap exits of joiners, but crash join channels if room goes down
-    {num, st} = assign_player(state, socket, 1)
+    {num, nu_state} = assign_player(state, socket, 1)
     # TODO: maybe singal in another field in return_args whether the room has 4 and should start
     # match (either joined, pos) or (koined, pos, ready!) or something
     # then, can signal to lock and bcast start to all
     # then, let client start sending velocity
-    players = Map.keys(st.players)
-    {:reply, {:ok, :joined, {num, players}}, st}
+    players = Map.keys(nu_state.players)
+    {:reply, {:ok, :joined, {num, players}}, nu_state}
+  end
+
+  def handle_call({:leave, pid}, _from, state) do
+    case Map.pop(state.player_pids, pid) do
+      {nil, _} -> {:reply, :ok, state}
+      {num, nu_pids} -> 
+        nu_players = Map.delete(state.players, num)
+        broadcast(nu_players, {:player_left, num})
+        {:reply,:ok, %{state | players: nu_players, player_pids: nu_pids}}
+    end
   end
 
   def handle_info(_msg, state) do
@@ -46,8 +63,15 @@ defmodule Agbic.GameRoom do
 
   defp assign_player(state, socket, num) do
     case Map.has_key?(state.players, num) do
-      false -> {num, %{state | players: Map.put(state.players, num, socket)}}
+      false -> {num, %{state | 
+        players: Map.put(state.players, num, socket),
+        player_pids: Map.put(state.player_pids, socket.channel_pid, num)}}
       true -> assign_player(state, socket, num + 1)
     end
+  end
+
+  defp broadcast(players, msg) do
+    players
+    |> Enum.each(fn {_num, sock} -> send(sock.channel_pid, msg) end)
   end
 end

--- a/agbic/mix.lock
+++ b/agbic/mix.lock
@@ -2,7 +2,7 @@
   "cowlib": {:hex, :cowlib, "1.0.2", "9d769a1d062c9c3ac753096f868ca121e2730b9a377de23dec0f7e08b1df84ee", [:make], []},
   "fs": {:hex, :fs, "0.9.2", "ed17036c26c3f70ac49781ed9220a50c36775c6ca2cf8182d123b6566e49ec59", [:rebar], []},
   "gettext": {:hex, :gettext, "0.11.0", "80c1dd42d270482418fa158ec5ba073d2980e3718bacad86f3d4ad71d5667679", [:mix], []},
-  "matchmaker": {:git, "https://github.com/coconaut/matchmaker.git", "222942b88790a5823e209a44eba56592e9256258", []},
+  "matchmaker": {:git, "https://github.com/coconaut/matchmaker.git", "68066cf4b9e5dcb24da867778beb086cf5b6b0e3", []},
   "phoenix": {:hex, :phoenix, "1.2.0", "1bdeb99c254f4c534cdf98fd201dede682297ccc62fcac5d57a2627c3b6681fb", [:mix], [{:poison, "~> 1.5 or ~> 2.0", [hex: :poison, optional: false]}, {:phoenix_pubsub, "~> 1.0", [hex: :phoenix_pubsub, optional: false]}, {:plug, "~> 1.1", [hex: :plug, optional: false]}, {:cowboy, "~> 1.0", [hex: :cowboy, optional: true]}]},
   "phoenix_html": {:hex, :phoenix_html, "2.6.2", "944a5e581b0d899e4f4c838a69503ebd05300fe35ba228a74439e6253e10e0c0", [:mix], [{:plug, "~> 1.0", [hex: :plug, optional: false]}]},
   "phoenix_live_reload": {:hex, :phoenix_live_reload, "1.0.5", "829218c4152ba1e9848e2bf8e161fcde6b4ec679a516259442561d21fde68d0b", [:mix], [{:phoenix, "~> 1.0 or ~> 1.2-rc", [hex: :phoenix, optional: false]}, {:fs, "~> 0.9.1", [hex: :fs, optional: false]}]},

--- a/agbic/mix.lock
+++ b/agbic/mix.lock
@@ -2,7 +2,7 @@
   "cowlib": {:hex, :cowlib, "1.0.2", "9d769a1d062c9c3ac753096f868ca121e2730b9a377de23dec0f7e08b1df84ee", [:make], []},
   "fs": {:hex, :fs, "0.9.2", "ed17036c26c3f70ac49781ed9220a50c36775c6ca2cf8182d123b6566e49ec59", [:rebar], []},
   "gettext": {:hex, :gettext, "0.11.0", "80c1dd42d270482418fa158ec5ba073d2980e3718bacad86f3d4ad71d5667679", [:mix], []},
-  "matchmaker": {:git, "https://github.com/coconaut/matchmaker.git", "c14a20905243a01e3602c6adda6506f27dac27ae", []},
+  "matchmaker": {:git, "https://github.com/coconaut/matchmaker.git", "fcefac7ab59ac964e0ea904f9febfba338fe4203", []},
   "phoenix": {:hex, :phoenix, "1.2.0", "1bdeb99c254f4c534cdf98fd201dede682297ccc62fcac5d57a2627c3b6681fb", [:mix], [{:poison, "~> 1.5 or ~> 2.0", [hex: :poison, optional: false]}, {:phoenix_pubsub, "~> 1.0", [hex: :phoenix_pubsub, optional: false]}, {:plug, "~> 1.1", [hex: :plug, optional: false]}, {:cowboy, "~> 1.0", [hex: :cowboy, optional: true]}]},
   "phoenix_html": {:hex, :phoenix_html, "2.6.2", "944a5e581b0d899e4f4c838a69503ebd05300fe35ba228a74439e6253e10e0c0", [:mix], [{:plug, "~> 1.0", [hex: :plug, optional: false]}]},
   "phoenix_live_reload": {:hex, :phoenix_live_reload, "1.0.5", "829218c4152ba1e9848e2bf8e161fcde6b4ec679a516259442561d21fde68d0b", [:mix], [{:phoenix, "~> 1.0 or ~> 1.2-rc", [hex: :phoenix, optional: false]}, {:fs, "~> 0.9.1", [hex: :fs, optional: false]}]},

--- a/agbic/mix.lock
+++ b/agbic/mix.lock
@@ -2,7 +2,7 @@
   "cowlib": {:hex, :cowlib, "1.0.2", "9d769a1d062c9c3ac753096f868ca121e2730b9a377de23dec0f7e08b1df84ee", [:make], []},
   "fs": {:hex, :fs, "0.9.2", "ed17036c26c3f70ac49781ed9220a50c36775c6ca2cf8182d123b6566e49ec59", [:rebar], []},
   "gettext": {:hex, :gettext, "0.11.0", "80c1dd42d270482418fa158ec5ba073d2980e3718bacad86f3d4ad71d5667679", [:mix], []},
-  "matchmaker": {:git, "https://github.com/coconaut/matchmaker.git", "68066cf4b9e5dcb24da867778beb086cf5b6b0e3", []},
+  "matchmaker": {:git, "https://github.com/coconaut/matchmaker.git", "c14a20905243a01e3602c6adda6506f27dac27ae", []},
   "phoenix": {:hex, :phoenix, "1.2.0", "1bdeb99c254f4c534cdf98fd201dede682297ccc62fcac5d57a2627c3b6681fb", [:mix], [{:poison, "~> 1.5 or ~> 2.0", [hex: :poison, optional: false]}, {:phoenix_pubsub, "~> 1.0", [hex: :phoenix_pubsub, optional: false]}, {:plug, "~> 1.1", [hex: :plug, optional: false]}, {:cowboy, "~> 1.0", [hex: :cowboy, optional: true]}]},
   "phoenix_html": {:hex, :phoenix_html, "2.6.2", "944a5e581b0d899e4f4c838a69503ebd05300fe35ba228a74439e6253e10e0c0", [:mix], [{:plug, "~> 1.0", [hex: :plug, optional: false]}]},
   "phoenix_live_reload": {:hex, :phoenix_live_reload, "1.0.5", "829218c4152ba1e9848e2bf8e161fcde6b4ec679a516259442561d21fde68d0b", [:mix], [{:phoenix, "~> 1.0 or ~> 1.2-rc", [hex: :phoenix, optional: false]}, {:fs, "~> 0.9.1", [hex: :fs, optional: false]}]},

--- a/agbic/web/channels/games_channel.ex
+++ b/agbic/web/channels/games_channel.ex
@@ -86,8 +86,15 @@ defmodule Agbic.GamesChannel do
     {:noreply, socket}
   end
 
+  def handle_info(:start, socket) do
+    Logger.debug "GamesChannel: starting!!!"
+    push(socket, "start", %{:start => true})
+    {:noreply, socket}
+  end
+
   def handle_info({:DOWN, ref, :process, _pid, _reason}, socket) do
-    # leave channel if room goes down
+    # leave channel if room goes down (for now)
+    # client, however, needs to leave channel or will try to rejoin...
     cond do
       ref == socket.assigns.room_ref -> {:stop, :normal, socket}
       true -> {:noreply, socket}

--- a/agbic/web/channels/games_channel.ex
+++ b/agbic/web/channels/games_channel.ex
@@ -81,7 +81,9 @@ defmodule Agbic.GamesChannel do
   end
 
   def handle_info({:player_left, num}, socket) do
+    Logger.debug "GamesChannel: player #{num} left, about to notify clients"
     push(socket, "player_left", %{player: num})
+    {:noreply, socket}
   end
 
   def handle_info({:DOWN, ref, :process, _pid, _reason}, socket) do

--- a/agbic/web/channels/games_channel.ex
+++ b/agbic/web/channels/games_channel.ex
@@ -4,6 +4,14 @@ defmodule Agbic.GamesChannel do
   alias Phoenix.Socket
   require Logger
 
+
+  # TODO: run matchmaker as embedded so we can deal w/pooling and upgrading max subs?
+  # or alternately, just read from ets, change if you upgrade matchmaker
+  # or don't allow change, but for now, just get this working...
+
+  @max_subscribers Application.get_env(:matchmaker, Matchmaker.Supervisor)[:max_subscribers]
+
+  
   # lock room and set start message when max subs reach
   # handle quits in room -> bcast to all and remove the player from state
   # matchmaker needs to handle bad rooms on decrement
@@ -40,7 +48,7 @@ defmodule Agbic.GamesChannel do
         {:ok, room_pid, {player_num, players}} -> 
           Logger.debug "Player #{player_num} joining room #{room_id}"
           room_ref = Process.monitor(room_pid)
-          send(self(), {:after_join, %{players: players}}) # after joining, handle this msg to bcast
+          send(self(), {:after_join, room_id, %{players: players}}) # after joining, handle this msg to bcast
           {:ok, %{player: player_num, players: players}, Socket.assign(socket, :room_ref, room_ref)}
         {:error, reason} -> 
           Logger.debug "ERROR RoomServer: #{reason}"
@@ -75,8 +83,17 @@ defmodule Agbic.GamesChannel do
     {:noreply, socket}
   end
 
-  def handle_info({:after_join, player_payload}, socket) do
+  def handle_info({:after_join, room_id, player_payload}, socket) do
     broadcast(socket, "player_joined", player_payload)
+    # check player payload to see if ready
+    if Enum.count(player_payload.players) == @max_subscribers do 
+      Logger.debug "about to tell room_server to lock room"
+      # TODO: come up w/ something better either here or when client subscribes...
+      # maybe client should send a ready signal, forward to GameRoom, let it handle
+      # when it's time to lock / start
+      :timer.sleep(1000)
+      RoomServer.lock_room(RoomServer, room_id)
+    end
     {:noreply, socket}
   end
 

--- a/agbic/web/static/js/obj/otherPlayer.js
+++ b/agbic/web/static/js/obj/otherPlayer.js
@@ -13,7 +13,7 @@ export class OtherPlayer extends Player{
     }
     
     updatePosition(movement){
-        //console.log("got movement", movement);
+        console.log("got movement", movement);
         this.x = movement.x;
         this.y = movement.y;
         this.gun.x = movement.x;

--- a/agbic/web/static/js/obj/otherPlayer.js
+++ b/agbic/web/static/js/obj/otherPlayer.js
@@ -13,7 +13,7 @@ export class OtherPlayer extends Player{
     }
     
     updatePosition(movement){
-        console.log("got movement", movement);
+        //console.log("got movement", movement);
         this.x = movement.x;
         this.y = movement.y;
         this.gun.x = movement.x;

--- a/agbic/web/static/js/state/play.js
+++ b/agbic/web/static/js/state/play.js
@@ -18,7 +18,8 @@ export class Play extends Phaser.State {
         console.log(players);
 
         // all future player joins can be handled here
-        this.channel.on("player_joined", this.playerJoined.bind(this)) // doesn't seem to recv self?
+        this.channel.on("player_joined", this.playerJoined.bind(this))
+        this.channel.on("player_left", this.playerLeft.bind(this))
         // todo: handle the start signal
 	}
 	
@@ -115,5 +116,9 @@ export class Play extends Phaser.State {
         this.otherPlayer = new OtherPlayer(this.game, 300, 300);
         this.otherPlayer.preload();
         this.otherPlayer.create(this.bullets, 2, this.channel);
+    }
+
+    playerLeft(msg) {
+        console.log("player left: " + msg.player);
     }
 }

--- a/agbic/web/static/js/state/play.js
+++ b/agbic/web/static/js/state/play.js
@@ -20,7 +20,7 @@ export class Play extends Phaser.State {
         // all future player joins can be handled here
         this.channel.on("player_joined", this.playerJoined.bind(this))
         this.channel.on("player_left", this.playerLeft.bind(this))
-        // todo: handle the start signal
+        this.channel.on("start", this.start.bind(this))
 	}
 	
     preload() {
@@ -120,5 +120,10 @@ export class Play extends Phaser.State {
 
     playerLeft(msg) {
         console.log("player left: " + msg.player);
+    }
+
+    start(msg) {
+        console.log("received start!");
+        console.log(msg);
     }
 }


### PR DESCRIPTION
Make sure to mix deps.update matchmaker. 

The start signal is a bit of a hack for now, as I had to add a delay so that the 4th player could subscribe to the start message in time. We might want to have each channel send a ready message back once they've subscribed to everything in the play state, or try to subscribe before we actually join the channel (although then the play state doesn't exist yet, so not sure how we'd swing it). But for now, should be good. 

Open up 4 tabs to get a {start: true} msg. 

Change the dev.config (:matchmaker, Matchmaker.Supervisor, :max_subscribers) if you want to bring the max count down from 4 for easier testing.
